### PR TITLE
revised ContextLoggerOptions

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -25,9 +25,8 @@ func TestFromContext(t *testing.T) {
 		scenario string
 		exec     func(t *testing.T)
 	}{
-		{scenario: "FromContext()/no logger in context",
+		{scenario: "FromContext()/no logger",
 			exec: func(t *testing.T) {
-				// ARRANGE
 				// ACT
 				result := FromContext(ctx)
 
@@ -35,13 +34,31 @@ func TestFromContext(t *testing.T) {
 				test.That(t, result).Equals(noop.logger)
 			},
 		},
-		{scenario: "FromContext(Required)/no logger in context",
+		{scenario: "FromContext()/no logger/NoopIfNotPresent",
 			exec: func(t *testing.T) {
-				// ARRANGE
+				// ACT
+				result := FromContext(ctx, NoopIfNotPresent)
+
+				// ASSERT
+				test.That(t, result).Equals(noop.logger)
+			},
+		},
+		{scenario: "FromContext/no logger/PanicIfNotPresent",
+			exec: func(t *testing.T) {
+				// ARRANGE ASSERT
 				defer test.ExpectPanic(ErrNoLoggerInContext).Assert(t)
 
 				// ACT
-				_ = FromContext(ctx, Required)
+				_ = FromContext(ctx, PanicIfNotPresent)
+			},
+		},
+		{scenario: "FromContext/no logger/NilIfNotPresent",
+			exec: func(t *testing.T) {
+				// ACT
+				result := FromContext(ctx, NilIfNotPresent)
+
+				// ASSERT
+				test.That(t, result).IsNil()
 			},
 		},
 		{scenario: "FromContext()/logger in context",

--- a/noop.go
+++ b/noop.go
@@ -18,6 +18,10 @@ var noop = &noopimpl{
 	entry: entry{noop: true},
 }
 
+// dispatch implements a no-op dispatch method allowing noop to
+// be used as a dispatcher.
+func (*noopimpl) dispatch(entry) { /* NO-OP */ }
+
 // Close implements a no-op Close method.
 func (*noopimpl) Close() { /* NO-OP */ }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Deprecated `ContextLoggerOption(1)` in favor of `PanicIfNotPresent`.
  - Introduced new `ContextLoggerOption` values: `NoopIfNotPresent`, `PanicIfNotPresent`, and `NilIfNotPresent`.
  - Updated `ulog.FromContext` to handle new `ContextLoggerOption` values.
  
- **Tests**
  - Updated test cases to reflect the new `PanicIfNotPresent` option.
  - Added new test scenarios for field merging behavior in the `WithField` method.

- **New Features**
  - Implemented `dispatch` and `Close` methods as no-ops in `noopimpl`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->